### PR TITLE
support setuptools whilst degrading gracefully if not available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+try:
+   from setuptools.commands import setup
+except:
+   from distutils.core import setup
 
 setup(name='WSDiscovery',
       version='0.2',
@@ -25,5 +28,6 @@ setup(name='WSDiscovery',
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Topic :: Communications'
       ],
-      py_modules=['WSDiscovery']
+      py_modules=['WSDiscovery'],
+      setup_requires=['netifaces']
      )


### PR DESCRIPTION
This fixes #11. Distutils support is maintained for cases when setuptools might not be available. Running 'python setup.py install' merely emits a warning in that case.