### PR TITLE
Add possibility of choosing a namespace prefix instead of a random one in QName

### DIFF
--- a/wsdiscovery/qname.py
+++ b/wsdiscovery/qname.py
@@ -5,15 +5,19 @@ Simple QName implementation
 
 class QName:
 
-    def __init__(self, namespace, localname):
+    def __init__(self, namespace, localname, namespace_prefix=None):
         self._namespace = namespace
         self._localname = localname
+        self._namespace_prefix = namespace_prefix
 
     def getNamespace(self):
         return self._namespace
 
     def getLocalname(self):
         return self._localname
+
+    def getNamespacePrefix(self):
+        return self._namespace_prefix
 
     def getFullname(self):
         return self.getNamespace() + ":" + self.getLocalname()

--- a/wsdiscovery/util.py
+++ b/wsdiscovery/util.py
@@ -60,11 +60,14 @@ def addTypes(doc, node, types):
         for type in types:
             ns = type.getNamespace()
             localname = type.getLocalname()
-            if prefixMap.get(ns) == None:
-                prefix = getRandomStr()
-                prefixMap[ns] = prefix
+            if type.getNamespacePrefix() is None:
+                if prefixMap.get(ns) == None:
+                    prefix = getRandomStr()
+                    prefixMap[ns] = prefix
+                else:
+                    prefix = prefixMap.get(ns)
             else:
-                prefix = prefixMap.get(ns)
+                prefix = type.getNamespacePrefix()
             addNSAttrToEl(envEl, ns, prefix)
             typeList.append(prefix + ":" + localname)
         addElementWithText(doc, node, "d:Types", NS_D, " ".join(typeList))
@@ -198,13 +201,15 @@ def getDefaultNamespace(node):
 def getQNameFromValue(value, node):
     vals = value.split(":")
     ns = ""
+    prefix = None
     if len(vals) == 1:
         localName = vals[0]
         ns = getDefaultNamespace(node)
     else:
         localName = vals[1]
-        ns = getNamespaceValue(node, vals[0])
-    return QName(ns, localName)
+        prefix = vals[0]
+        ns = getNamespaceValue(node, prefix)
+    return QName(ns, localName, prefix)
 
 
 def _getNetworkAddrs():


### PR DESCRIPTION
We are currently using this library in a project involving ONVIF. We recently discovered a bug where some ONVIF implementations went against the specs and hardcoded the values of the namespace prefix.

More specifically, an XML file with ```xmlns:<random str>``` in the header would not produce an answer from the camera considering it invalid. If instead the XML has ```xmlns:dn``` then it would produce a response as the camera considers it valid.

This patch therefore allows the user to specify the ```xmlns``` target prefix instead of relying on the library creating a random one