### PR TITLE
Allow InstanceId == 0

### DIFF
--- a/wsdiscovery/daemon.py
+++ b/wsdiscovery/daemon.py
@@ -196,7 +196,7 @@ class NetworkingThread(_StoppableDaemonThread):
 
             iid = env.getInstanceId()
             mid = env.getMessageId()
-            if len(iid) > 0 and int(iid) > 0:
+            if len(iid) > 0 and int(iid) >= 0:
                 mnum = env.getMessageNumber()
                 key = addr[0] + ":" + str(addr[1]) + ":" + str(iid)
                 if mid is not None and len(mid) > 0:

--- a/wsdiscovery/daemon.py
+++ b/wsdiscovery/daemon.py
@@ -195,7 +195,6 @@ class NetworkingThread(_StoppableDaemonThread):
                 self._knownMessageIds.add(mid)
 
             iid = env.getInstanceId()
-            mid = env.getMessageId()
             if len(iid) > 0 and int(iid) >= 0:
                 mnum = env.getMessageNumber()
                 key = addr[0] + ":" + str(addr[1]) + ":" + str(iid)


### PR DESCRIPTION
It's unsignedInt per the spec, i.e. >= 0.

The redundant getMessageId call was just staring at me there when fixing this, so included here even if it's unrelated :)