### PR TITLE
Avoid crash with ProbeMatch without To

### DIFF
--- a/wsdiscovery/actions/probematch.py
+++ b/wsdiscovery/actions/probematch.py
@@ -47,7 +47,10 @@ def parseProbeMatchMessage(dom):
 
     env.setMessageId(dom.getElementsByTagNameNS(NS_A, "MessageID")[0].firstChild.data.strip())
     env.setRelatesTo(dom.getElementsByTagNameNS(NS_A, "RelatesTo")[0].firstChild.data.strip())
-    env.setTo(dom.getElementsByTagNameNS(NS_A, "To")[0].firstChild.data.strip())
+    # Even though To is required in WS-Discovery, some devices omit it
+    elem = dom.getElementsByTagNameNS(NS_A, "To").item(0)
+    if elem:
+        env.setTo(elem.firstChild.data.strip())
 
     _parseAppSequence(dom, env)
 


### PR DESCRIPTION
[To is required per the spec](http://docs.oasis-open.org/ws-dd/discovery/1.1/os/wsdd-discovery-1.1-spec-os.html#_Toc234231835), but for example the [IP Webcam for Android](https://play.google.com/store/apps/details?id=com.pas.webcam&hl=en) omits it.
