### PR TITLE
Make sure ThreadedWSDiscovery.stop() also stops all threads

### DIFF
--- a/wsdiscovery/discovery.py
+++ b/wsdiscovery/discovery.py
@@ -130,6 +130,7 @@ class Discovery:
 
     def stop(self):
         self.clearRemoteServices()
+        super().stop()
 
 
 class ThreadedWSDiscovery(Daemon, Discovery, ThreadedNetworking):


### PR DESCRIPTION
**Problem**

After running a discovery scan, the discovery threads keep running. This causes a memory leak if multiple scans are done in succession.

**Solution**

Make sure `ThreadedWSDiscovery.stop()` also stops all threads by calling it's 'parent', which is the next mixin, `ThreadedNetworking.stop()`.