### PR TITLE
better capture logging

### DIFF
--- a/wsdiscovery/message.py
+++ b/wsdiscovery/message.py
@@ -1,6 +1,6 @@
 """Functions to serialize and deserialize messages between SOAP envelope & string representations"""
 
-import io
+import io, sys
 from .namespaces import NS_ADDRESSING, NS_SOAPENV
 from .actions import *
 from xml.dom import minidom
@@ -25,7 +25,6 @@ def createSOAPMessage(env):
 
 def parseSOAPMessage(data, ipAddr):
     "deserialize XML message strings into SOAP envelope objects"
-
     try:
         dom = minidom.parseString(data)
     except Exception:
@@ -33,7 +32,7 @@ def parseSOAPMessage(data, ipAddr):
         return None
 
     if dom.getElementsByTagNameNS(NS_SOAPENV, "Fault"):
-        #print('Fault received from %s:' % (ipAddr, data), file=sys.stderr)
+        #print('Fault received from %s %s:' % (ipAddr, data), file=sys.stderr)
         return None
 
     soapAction = dom.getElementsByTagNameNS(NS_ADDRESSING, "Action")[0].firstChild.data.strip()

--- a/wsdiscovery/util.py
+++ b/wsdiscovery/util.py
@@ -281,3 +281,11 @@ def showEnv(env):
     print("Probe Matches: %s" % env.getProbeResolveMatches())
     print("-----------------------------")
 
+
+
+def dom2Str(data):
+    dom = minidom.parseString(data)
+    return "\n" + dom.toprettyxml(indent="  ") + "\n"
+
+
+


### PR DESCRIPTION
In order to track what happened with the [TP-LINK camera issue](https://github.com/andreikop/python-ws-discovery/issues/56), I needed to modify the capture feature of wsdiscover a bit:

- xml messages are pretty-formatted in the capture file
- Also the messages with ``<SOAP-ENV:Fault>`` are logged (instead of silently ommitting them), so we get an idea of the potential errors
- Timestamps and interfaces are written into the capture file

For an example output in the capture file, please see that issue about tp-link cams