### PR TITLE
Expose service discovery timeout to CLI

### DIFF
--- a/wsdiscovery/cmdline.py
+++ b/wsdiscovery/cmdline.py
@@ -7,6 +7,7 @@ from wsdiscovery.discovery import ThreadedWSDiscovery as WSDiscovery
 from wsdiscovery.publishing import ThreadedWSPublishing as WSPublishing
 from wsdiscovery.scope import Scope
 from wsdiscovery.qname import QName
+from wsdiscovery.discovery import DEFAULT_DISCOVERY_TIMEOUT
 
 DEFAULT_LOGLEVEL = "INFO"
 
@@ -43,14 +44,17 @@ def setup_logger(name, loglevel):
               type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
               help='Log level')
 @click.option('--capture', '-c', nargs=1, type=click.File('w'), help='Capture messages to a file')
-def discover(scope, address, port, loglevel, capture):
+@click.option('--timeout', '-t', default=DEFAULT_DISCOVERY_TIMEOUT, show_default=True,
+              type=int, help='Discovery timeout in seconds')
+def discover(scope, address, port, loglevel, capture, timeout):
     "Discover services using WS-Discovery"
 
     logger = setup_logger("ws-discovery", loglevel)
 
     with discovery(capture) as wsd:
         scopes = [Scope(scope)] if scope else []
-        svcs = wsd.searchServices(scopes=scopes, address=address, port=port)
+        svcs = wsd.searchServices(scopes=scopes, address=address, port=port,
+                                  timeout=timeout)
         print("\nDiscovered:\n")
         for service in svcs:
             url = urlparse(service.getXAddrs()[0])

--- a/wsdiscovery/discovery.py
+++ b/wsdiscovery/discovery.py
@@ -11,6 +11,8 @@ from .namespaces import NS_DISCOVERY
 from .threaded import ThreadedNetworking
 from .daemon import Daemon
 
+DEFAULT_DISCOVERY_TIMEOUT = 3
+
 
 class Discovery:
     """networking-agnostic generic remote service discovery mixin"""
@@ -117,8 +119,9 @@ class Discovery:
 
         self._remoteServices.clear()
 
-    def searchServices(self, types=None, scopes=None, address=None, port=None, timeout=3):
-        'search for services given the TYPES and SCOPES in a given TIMEOUT'
+    def searchServices(self, types=None, scopes=None, address=None, port=None,
+                       timeout=DEFAULT_DISCOVERY_TIMEOUT):
+        'search for services given the TYPES and SCOPES within a given TIMEOUT'
         try:
             self._sendProbe(types, scopes, address, port)
         except:


### PR DESCRIPTION
With this, we can experiment with service discovery timeout (waiting period) directly using the CLI.