### PR TITLE
Allow user to customize Unicast and Multicast message repeat counts

### DIFF
--- a/wsdiscovery/cmdline.py
+++ b/wsdiscovery/cmdline.py
@@ -50,12 +50,11 @@ def setup_logger(name, loglevel):
 @click.option('--capture', '-c', nargs=1, type=click.File('w'), help='Capture messages to a file')
 @click.option('--timeout', '-t', default=DEFAULT_DISCOVERY_TIMEOUT, show_default=True,
               type=int, help='Discovery timeout in seconds')
-def discover(scope, address, port, loglevel, capture, timeout):
 @click.option('--unicast-num', '-un', type=int, default=UNICAST_UDP_REPEAT,
               show_default=True, help='Number of Unicast messages to send')
 @click.option('--multicast-num', '-mn', type=int, default=MULTICAST_UDP_REPEAT,
               show_default=True, help='Number of Multicast messages to send')
-def discover(scope, address, port, loglevel, capture, unicast_num,
+def discover(scope, address, port, loglevel, capture, timeout, unicast_num,
              multicast_num):
     "Discover services using WS-Discovery"
 

--- a/wsdiscovery/daemon.py
+++ b/wsdiscovery/daemon.py
@@ -9,7 +9,7 @@ from .actions import *
 from .uri import URI
 from .service import Service
 from .envelope import SoapEnvelope
-
+from .udp import UNICAST_UDP_REPEAT, MULTICAST_UDP_REPEAT
 
 APP_MAX_DELAY = 500 # miliseconds
 
@@ -33,6 +33,8 @@ class Daemon:
 
         self._capture = capture
         self.ttl = ttl
+        self._unicast_num = kwargs.get('unicast_num', UNICAST_UDP_REPEAT)
+        self._multicast_num = kwargs.get('multicast_num', MULTICAST_UDP_REPEAT)
 
         super().__init__(**kwargs)
 
@@ -48,35 +50,39 @@ class Daemon:
 
     def _sendResolveMatch(self, service, relatesTo, addr):
         env = constructResolveMatch(service, relatesTo)
-        self.sendUnicastMessage(env, addr[0], addr[1])
+        self.sendUnicastMessage(env, addr[0], addr[1], unicast_num=self._unicast_num)
 
     def _sendProbeMatch(self, services, relatesTo, addr):
         env = constructProbeMatch(services, relatesTo)
-        self.sendUnicastMessage(env, addr[0], addr[1], random.randint(0, APP_MAX_DELAY))
+        self.sendUnicastMessage(env, addr[0], addr[1], random.randint(0, APP_MAX_DELAY),
+                                unicast_num=self._unicast_num)
 
     def _sendProbe(self, types=None, scopes=None, address=None, port=None):
         env = constructProbe(types, scopes)
         if self._dpActive:
-            self.sendUnicastMessage(env, self._dpAddr[0], self._dpAddr[1])
+            self.sendUnicastMessage(env, self._dpAddr[0], self._dpAddr[1],
+                                    unicast_num=self._unicast_num)
         elif address and port:
-            self.sendUnicastMessage(env, address, port)
+            self.sendUnicastMessage(env, address, port,
+                                    unicast_num=self._unicast_num)
         else:
-            self.sendMulticastMessage(env)
+            self.sendMulticastMessage(env, multicast_num=self._multicast_num)
 
     def _sendResolve(self, epr):
         env = constructResolve(epr)
         if self._dpActive:
-            self.sendUnicastMessage(env, self._dpAddr[0], self._dpAddr[1])
+            self.sendUnicastMessage(env, self._dpAddr[0], self._dpAddr[1],
+                                    unicast_num=self._unicast_num)
         else:
-            self.sendMulticastMessage(env)
+            self.sendMulticastMessage(env, multicast_num=self._multicast_num)
 
     def _sendHello(self, service):
         env = constructHello(service)
         random.seed((int)(time.time() * 1000000))
-        self.sendMulticastMessage(env,initialDelay=random.randint(0, APP_MAX_DELAY))
+        self.sendMulticastMessage(env,initialDelay=random.randint(0, APP_MAX_DELAY),
+                                  multicast_num=self._multicast_num)
 
     def _sendBye(self, service):
         env = constructBye(service)
         service.incrementMessageNumber()
-        self.sendMulticastMessage(env)
-
+        self.sendMulticastMessage(env, multicast_num=self._multicast_num)

--- a/wsdiscovery/udp.py
+++ b/wsdiscovery/udp.py
@@ -26,11 +26,13 @@ MULTICAST_UDP_UPPER_DELAY=500
 class UDPMessage:
     "UDP message management implementation"
 
-    MULTICAST = 'multicast'
     UNICAST = 'unicast'
+    MULTICAST = 'multicast'
 
-    def __init__(self, env, addr, port, msgType, initialDelay=0):
-        """msgType shall be UDPMessage.MULTICAST or UDPMessage.UNICAST"""
+    def __init__(self, env, addr, port, msgType, initialDelay=0,
+                 unicast_num=UNICAST_UDP_REPEAT,
+                 multicast_num=MULTICAST_UDP_REPEAT):
+        """msgType shall be UDPMessage.UNICAST or UDPMessage.MULTICAST"""
         self._env = env
         self._addr = addr
         self._port = port
@@ -38,13 +40,13 @@ class UDPMessage:
 
         if msgType == self.UNICAST:
             udpRepeat, udpMinDelay, udpMaxDelay, udpUpperDelay = \
-                    UNICAST_UDP_REPEAT, \
+                    unicast_num, \
                     UNICAST_UDP_MIN_DELAY, \
                     UNICAST_UDP_MAX_DELAY, \
                     UNICAST_UDP_UPPER_DELAY
         else:
             udpRepeat, udpMinDelay, udpMaxDelay, udpUpperDelay = \
-                    MULTICAST_UDP_REPEAT, \
+                    multicast_num, \
                     MULTICAST_UDP_MIN_DELAY, \
                     MULTICAST_UDP_MAX_DELAY, \
                     MULTICAST_UDP_UPPER_DELAY
@@ -79,5 +81,3 @@ class UDPMessage:
             self._t = self._udpUpperDelay
         self._nextTime = int(time.time() * 1000) + self._t
         self._udpRepeat = self._udpRepeat - 1
-
-


### PR DESCRIPTION
With this, we can specify how many repetitive UDP messages to send. For example, the default number of UDP messages to send for multicast is 4. With this patch I can set the number to 1, thus making our behavior more similar to other WS Discovery tools, like for example `onvif-util`.