### PR TITLE
Fix pytest issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ environment and set up a development environment. For example:
 ```
 $ python3 -m venv venv
 $ . venv/bin/activate
-(venv) $ pip3 install -e
+(venv) $ pip3 install -e .
 ```
 Then you can call `wsdiscover` and `wspublish` from within this virtual
 environment. Any code changes to the package will be available and testable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-netifaces-plus
+ifaddr
 click

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(name='WSDiscovery',
             'Topic :: Communications'
       ],
       packages=['wsdiscovery', 'wsdiscovery.actions'],
-      setup_requires=['netifaces-plus', 'click'],
-      install_requires=['netifaces-plus', 'click'],
+      setup_requires=['ifaddr', 'click'],
+      install_requires=['ifaddr', 'click'],
       tests_require = ['pytest', 'mock'],
       entry_points = {
          'console_scripts': [

--- a/wsdiscovery/threaded.py
+++ b/wsdiscovery/threaded.py
@@ -308,6 +308,7 @@ class NetworkingThreadIPv4(NetworkingThread):
         super().__init__(observer)
 
     def _makeMreq(self, addr):
+        "IPvv multicast group join/leave request"
         return struct.pack("4s4s", socket.inet_aton(MULTICAST_IPV4_ADDRESS), addr.packed)
 
     def _get_inet(self):
@@ -334,6 +335,7 @@ class NetworkingThreadIPv6(NetworkingThread):
         super().__init__(observer)
 
     def _makeMreq(self, addr):
+        "IPv6 multicast group join/leave request"
         return struct.pack("=16si", socket.inet_pton(socket.AF_INET6, MULTICAST_IPV6_ADDRESS), int(addr.scope_id))
 
     def _get_inet(self):


### PR DESCRIPTION
This fixes #61 

What I've changed:
- Swap out `netifaces-plus` with `ifaddr`.
- Refactored _getNetworkAddrs to use `ifaddr`.

Reasons for using `ifaddr`:
- The maintainer of `netifaces-plus` recommends `ifaddr`.
- `ifaddr` is a pure python package.
- `ifaddr` provides RFC4007 scope id as a number, while `netifaces-plus` provides the scope id as the interface name (on Linux). Therefore we can just use the number (actually, interface number), no need to convert back from interface name to interface number.

I've made a small test for comparison, here: https://github.com/wpyoga/python-ifaces-test