### PR TITLE
Disable GH Actions fail-fast parameter

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,9 +11,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 


### PR DESCRIPTION
This prevents all tests to be cancelled when one test fails.

For example, after the IPv6 scope ID issue is fixed, the automated tests on Python 3.7 and Python 3.8 will fail (because of other reasons). When one test fails, all the other tests are cancelled.

With this patch, the other tests will not be cancelled.