### PR TITLE
Add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.13 has been released for some time now. The stable Docker version of Home Assistant, which uses this package, is also based on Python 3.13 . Makes sense to add the new version to the test matrix.