### PR TITLE
Handle no action being present in the SOAP message

### DIFF
--- a/wsdiscovery/message.py
+++ b/wsdiscovery/message.py
@@ -35,7 +35,12 @@ def parseSOAPMessage(data, ipAddr):
         #print('Fault received from %s %s:' % (ipAddr, data), file=sys.stderr)
         return None
 
-    soapAction = dom.getElementsByTagNameNS(NS_ADDRESSING, "Action")[0].firstChild.data.strip()
+    actions = dom.getElementsByTagNameNS(NS_ADDRESSING, "Action")
+    if len(actions) == 0:
+        #print('No action received from %s %s' % (ipAddr, data), file=sys.stderr)
+        return None
+
+    soapAction = actions[0].firstChild.data.strip()
     if soapAction == NS_ACTION_PROBE:
         return parseProbeMessage(dom)
     elif soapAction == NS_ACTION_PROBE_MATCH:


### PR DESCRIPTION
This causes an uncaught thread exception
```
025-01-23 09:11:18.656 ERROR (Thread-15) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/wsdiscovery/threaded.py", line 151, in run
    self._recvMessages()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/wsdiscovery/threaded.py", line 162, in _recvMessages
    env = parseSOAPMessage(data, addr[0])
  File "/Users/bdraco/home-assistant/venv/lib/python3.13/site-packages/wsdiscovery/message.py", line 39, in parseSOAPMessage
    soapAction = dom.getElementsByTagNameNS(NS_ADDRESSING, "Action")[0].firstChild.data.strip()
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```