### PR TITLE
Ensure a single bad message does not cause a thread exception

### DIFF
--- a/wsdiscovery/threaded.py
+++ b/wsdiscovery/threaded.py
@@ -195,7 +195,11 @@ class NetworkingThread(_StoppableDaemonThread):
                 time.sleep(0.01)
                 continue
 
-            env = parseSOAPMessage(data, addr[0])
+            try:
+                env = parseSOAPMessage(data, addr[0])
+            except Exception as e:
+                logger.debug("Failed to parse message from %s\n%s: %s", addr[0], data, e, exc_info=True)
+                env = None
 
             if env is None:  # fault or failed to parse
                 if self._capture:


### PR DESCRIPTION
If a single message cannot be parsed and throws, the whole thread would collapse and no more messages would be parsed see exception in #82

Its unfortunately common for poorly built devices to send invalid messages which cannot be parsed. We still want to get messages from working devices on the network.