### PR TITLE
Handle socket.IPV6_MULTICAST_IF failing to be set

### DIFF
--- a/wsdiscovery/threaded.py
+++ b/wsdiscovery/threaded.py
@@ -121,7 +121,15 @@ class NetworkingThread(_StoppableDaemonThread):
         else:
             iface = int(addr.scope_id)
 
-        sock.setsockopt(ip_proto, self._get_multicast(), iface)
+        try:
+            sock.setsockopt(ip_proto, self._get_multicast(), iface)
+        except OSError as e:
+            logger.warning(
+                "Interface for %s does not support "
+                "multicast flags or is not UP: OSError %s",
+                addr,
+                e
+            )
 
         return sock
 


### PR DESCRIPTION
If the IPv6 interface is not up, does not support multicast, or is disabled, this call will fail, however IPv4 will still work (after https://github.com/andreikop/python-ws-discovery/pull/85).

fixes #86