### PR TITLE
Removing call to basicConfig

### DIFF
--- a/wsdiscovery/cmdline.py
+++ b/wsdiscovery/cmdline.py
@@ -39,9 +39,9 @@ def setup_logger(name, loglevel):
         print("Invalid log level '%s'" % loglevel)
         sys.exit()
 
-    logging.basicConfig(level=level)
-    return logging.getLogger(name)
-
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    return logger
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--scope', '-s', help='Probe scope URI, e.g. onvif://www.onvif.org/Model/')


### PR DESCRIPTION
I noticed while using this library that it makes a call to logging.basicConfig. I don't believe libraries should do this. logging.basicConfig should be called only once per runtime. Our software is trying to use python-ws-discovery, and we are finding that is it overriding our logging config. 